### PR TITLE
fix: add classicMapper for classic icon url

### DIFF
--- a/internal/app/api/common/terraswap/classic.repository.go
+++ b/internal/app/api/common/terraswap/classic.repository.go
@@ -1,6 +1,9 @@
 package terraswap
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/terraswap/terraswap-service/internal/pkg/terraswap"
 	"github.com/terraswap/terraswap-service/internal/pkg/terraswap/databases"
@@ -12,10 +15,14 @@ type classicRepositoryImpl struct {
 	rdb.TerraswapRdb
 }
 
+type classicMapper struct {
+	mapperImpl
+}
+
 var _ repository = &classicRepositoryImpl{}
 
 func NewClassicRepo(chainId string, store databases.TerraswapDb, rdb rdb.TerraswapRdb) repository {
-	repo := &repositoryImpl{chainId, store, mapper{}}
+	repo := &repositoryImpl{chainId, store, &classicMapper{}}
 	return &classicRepositoryImpl{repo, rdb}
 }
 
@@ -26,4 +33,25 @@ func (r *classicRepositoryImpl) getZeroPoolPairs(pairs []terraswap.Pair) (map[st
 		return nil, errors.Wrap(err, "terraswap.ClassicRepository.GetZeroPoolPairs")
 	}
 	return zeroPoolPairsMap, nil
+}
+
+func (m *classicMapper) denomAddrToToken(denom string) terraswap.Token {
+	icon := ""
+	symbol := ""
+	if denom == "uluna" {
+		symbol = "LUNC"
+		icon = fmt.Sprintf(`%s/%s.svg`, terraswap.DenomIconUrl, symbol)
+	} else { // ex) uusd, ukrw ...
+		symbol = strings.ToUpper(denom[1:3]) + "T"
+		icon = fmt.Sprintf(`%s/%s.svg`, terraswap.ClassicDenomIconUrl, strings.ToUpper(symbol))
+	}
+
+	return terraswap.Token{
+		Name:         denom,
+		Symbol:       symbol,
+		Decimals:     6,
+		ContractAddr: denom,
+		Icon:         icon,
+		Verified:     true,
+	}
 }

--- a/internal/app/api/common/terraswap/repository.go
+++ b/internal/app/api/common/terraswap/repository.go
@@ -25,13 +25,18 @@ type repositoryImpl struct {
 	store   databases.TerraswapDb
 	mapper  mapper
 }
+type mapper interface {
+	denomAddrToToken(denom string) terraswap.Token
+	ibcDenomTraceToToken(ibcHash string, trace terraswap.IbcDenomTrace) terraswap.Token
+	ibcAllowlistToToken(v allowlist.IbcTokenAllowlist) terraswap.Token
+}
 
-type mapper struct{}
+type mapperImpl struct{}
 
 var _ repository = &repositoryImpl{}
 
 func NewRepo(chainId string, store databases.TerraswapDb) repository {
-	return &repositoryImpl{chainId, store, mapper{}}
+	return &repositoryImpl{chainId, store, &mapperImpl{}}
 }
 
 // GetAllPairs implements repository
@@ -166,7 +171,7 @@ func (r *repositoryImpl) getActiveDenoms() ([]string, error) {
 	return denoms, nil
 }
 
-func (m *mapper) denomAddrToToken(denom string) terraswap.Token {
+func (m *mapperImpl) denomAddrToToken(denom string) terraswap.Token {
 	symbol := terraswap.ToDenomSymbol(denom)
 	return terraswap.Token{
 		Name:         denom,
@@ -178,7 +183,7 @@ func (m *mapper) denomAddrToToken(denom string) terraswap.Token {
 	}
 }
 
-func (m *mapper) ibcDenomTraceToToken(ibcHash string, trace terraswap.IbcDenomTrace) terraswap.Token {
+func (m *mapperImpl) ibcDenomTraceToToken(ibcHash string, trace terraswap.IbcDenomTrace) terraswap.Token {
 	symbol := terraswap.ToDenomSymbol(trace.BaseDenom)
 	return terraswap.Token{
 		Name:         ibcHash,
@@ -189,7 +194,7 @@ func (m *mapper) ibcDenomTraceToToken(ibcHash string, trace terraswap.IbcDenomTr
 	}
 }
 
-func (m *mapper) ibcAllowlistToToken(v allowlist.IbcTokenAllowlist) terraswap.Token {
+func (m *mapperImpl) ibcAllowlistToToken(v allowlist.IbcTokenAllowlist) terraswap.Token {
 	decimals := v.Decimals
 	if decimals == 0 {
 		decimals = 6

--- a/internal/pkg/terraswap/constants.go
+++ b/internal/pkg/terraswap/constants.go
@@ -11,8 +11,9 @@ const (
 )
 
 const (
-	DenomIconUrl = "https://raw.githubusercontent.com/terra-money/assets/master/icon/svg"
-	IbcIconUrl   = "https://raw.githubusercontent.com/terra-money/assets/master/icon/svg/ibc"
+	ClassicDenomIconUrl = "https://raw.githubusercontent.com/terra-money/assets/master/icon/svg/Terra"
+	DenomIconUrl        = "https://raw.githubusercontent.com/terra-money/assets/master/icon/svg"
+	IbcIconUrl          = "https://raw.githubusercontent.com/terra-money/assets/master/icon/svg/ibc"
 )
 
 const (


### PR DESCRIPTION
## Summary
- implements classic mapper (since Terraswap on the classic network has a different icon URL)
 