### PR TITLE
fix: filter pair with invalid asset

### DIFF
--- a/internal/app/api/common/terraswap/classic.repository.go
+++ b/internal/app/api/common/terraswap/classic.repository.go
@@ -26,6 +26,30 @@ func NewClassicRepo(chainId string, store databases.TerraswapDb, rdb rdb.Terrasw
 	return &classicRepositoryImpl{repo, rdb}
 }
 
+// getAllPairs implements repository
+func (r *classicRepositoryImpl) getAllPairs() ([]terraswap.Pair, error) {
+	pairs, err := r.repository.getAllPairs()
+	if err != nil {
+		return nil, errors.Wrap(err, "terraswap.classicRepositoryImpl.getAllPairs")
+	}
+
+	filtered := []terraswap.Pair{}
+
+	for _, pair := range pairs {
+		invalid := false
+		for _, asset := range pair.AssetInfos {
+			if !terraswap.IsValidToken(asset.GetKey()) {
+				invalid = true
+			}
+		}
+		if invalid {
+			continue
+		}
+		filtered = append(filtered, pair)
+	}
+	return filtered, nil
+}
+
 // GetZeroPoolPairs implements repository
 func (r *classicRepositoryImpl) getZeroPoolPairs(pairs []terraswap.Pair) (map[string]bool, error) {
 	if r.TerraswapRdb == nil {

--- a/internal/app/api/common/terraswap/repository.go
+++ b/internal/app/api/common/terraswap/repository.go
@@ -39,7 +39,7 @@ func NewRepo(chainId string, store databases.TerraswapDb) repository {
 	return &repositoryImpl{chainId, store, &mapperImpl{}}
 }
 
-// GetAllPairs implements repository
+// getAllPairs implements repository
 func (r *repositoryImpl) getAllPairs() ([]terraswap.Pair, error) {
 	allPairs := []terraswap.Pair{}
 	lastPair := terraswap.Pair{}

--- a/internal/pkg/terraswap/databases/grpc/classic.grpc.go
+++ b/internal/pkg/terraswap/databases/grpc/classic.grpc.go
@@ -68,7 +68,7 @@ func (t *terraswapClassicGrpcCon) getPoolInfo(addr string) (*terraswap.PoolInfo,
 		QueryMsg:        []byte(`{"pool":{}}`),
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "grpc.getPairInfo(%s)", addr)
+		return nil, errors.Wrapf(err, "grpc.getPoolInfo(%s)", addr)
 	}
 
 	type poolInfoRes struct {


### PR DESCRIPTION
## Background
- When a blockchain node receives a query for a pair with an invalid asset, it recovers from the panic state.

## Summary
- filter pairs with invalid asset